### PR TITLE
Spanish translation update for 0.83.21 version

### DIFF
--- a/contrib/translations/es/es_ES.lng
+++ b/contrib/translations/es/es_ES.lng
@@ -3021,7 +3021,7 @@ Comandos DOS
 Depurador
 .
 :MENU:HelpDebugMenu
-Logging console
+Consola de registro
 .
 :MENU:debug_blankrefreshtest
 Prueba de refresco (pantalla en blanco)


### PR DESCRIPTION
Translates untranslated text option "Logging Console" menu item in 0.83.21 version

